### PR TITLE
Implement cross chunk face culling

### DIFF
--- a/include/blocks.h
+++ b/include/blocks.h
@@ -6,11 +6,12 @@ static const float TILE_OFFSET = 0.25f;
 /**
  * @brief Stores two texture coordinates. */
 typedef struct {
-	float u, v;
+        float u, v;
 } uv_t;
 
 /**
- * @brief Stores the top-left coordinates of a block UV on the texture Atlas.*/
+ * @brief Stores the top-left coordinates of a block UV on the texture
+ * Atlas.*/
 typedef struct {
         uv_t top;
         uv_t bottom;
@@ -27,53 +28,58 @@ typedef enum {
         BLOCK_STONE = 1,
         BLOCK_COBBLESTONE = 2,
         BLOCK_DIRT = 3,
-	BLOCK_GRASS = 4,
+        BLOCK_GRASS = 4,
         BLOCK_SAND = 5
 } block_type_t;
 
 /**
  * @brief Defines the texture mapping for each block type */
 static const block_uv_t BLOCK_UVS[] = {
-    [BLOCK_STONE] = {
-	    .top = {0.00f, 0.00f},
-	    .bottom = {0.00f, 0.00f},
-	    .front = {0.00f, 0.00f},
-	    .back = {0.00f, 0.00f},
-	    .left = {0.00f, 0.00f},
-	    .right = {0.00f, 0.00f},
-    },
-    [BLOCK_COBBLESTONE] = {
-	    .top = {0.25f, 0.00f},
-	    .bottom = {0.25f, 0.00f},
-	    .front = {0.25f, 0.00f},
-	    .back = {0.25f, 0.00f},
-	    .left = {0.25f, 0.00f},
-	    .right = {0.25f, 0.00f},
-    },
-    [BLOCK_DIRT] = {
-	    .top = {0.5f, 0.00f},
-	    .bottom = {0.5f, 0.00f},
-	    .front = {0.5f, 0.00f},
-	    .back = {0.5f, 0.00f},
-	    .left = {0.5f, 0.00f},
-	    .right = {0.5f, 0.00f},
-    },
-    [BLOCK_GRASS] = {
-	    .top = {0.00f, 0.25f},
-	    .bottom = {0.5f, 0.00f},
-	    .front = {0.75f, 0.00f},
-	    .back = {0.75f, 0.00f},
-	    .right = {0.75f, 0.00f},
-	    .left = {0.75f, 0.00f},
-    },
-    [BLOCK_SAND] = {
-	    .top = {0.25f, 0.25f},
-	    .bottom = {0.25f, 0.25f},
-	    .front = {0.25f, 0.25f},
-	    .back = {0.25f, 0.25f},
-	    .right = {0.25f, 0.25f},
-	    .left = {0.25f, 0.25f},
-    },
+    [BLOCK_STONE] =
+        {
+            .top = {0.00f, 0.00f},
+            .bottom = {0.00f, 0.00f},
+            .front = {0.00f, 0.00f},
+            .back = {0.00f, 0.00f},
+            .left = {0.00f, 0.00f},
+            .right = {0.00f, 0.00f},
+        },
+    [BLOCK_COBBLESTONE] =
+        {
+            .top = {0.25f, 0.00f},
+            .bottom = {0.25f, 0.00f},
+            .front = {0.25f, 0.00f},
+            .back = {0.25f, 0.00f},
+            .left = {0.25f, 0.00f},
+            .right = {0.25f, 0.00f},
+        },
+    [BLOCK_DIRT] =
+        {
+            .top = {0.5f, 0.00f},
+            .bottom = {0.5f, 0.00f},
+            .front = {0.5f, 0.00f},
+            .back = {0.5f, 0.00f},
+            .left = {0.5f, 0.00f},
+            .right = {0.5f, 0.00f},
+        },
+    [BLOCK_GRASS] =
+        {
+            .top = {0.00f, 0.25f},
+            .bottom = {0.5f, 0.00f},
+            .front = {0.75f, 0.00f},
+            .back = {0.75f, 0.00f},
+            .right = {0.75f, 0.00f},
+            .left = {0.75f, 0.00f},
+        },
+    [BLOCK_SAND] =
+        {
+            .top = {0.25f, 0.25f},
+            .bottom = {0.25f, 0.25f},
+            .front = {0.25f, 0.25f},
+            .back = {0.25f, 0.25f},
+            .right = {0.25f, 0.25f},
+            .left = {0.25f, 0.25f},
+        },
 };
 
 #endif

--- a/include/blocks.h
+++ b/include/blocks.h
@@ -48,7 +48,7 @@ static const block_uv_t BLOCK_UVS[] = {
 	    .front = {0.25f, 0.00f},
 	    .back = {0.25f, 0.00f},
 	    .left = {0.25f, 0.00f},
-	    .right = {0.25, 0.00f},
+	    .right = {0.25f, 0.00f},
     },
     [BLOCK_DIRT] = {
 	    .top = {0.5f, 0.00f},

--- a/include/camera.h
+++ b/include/camera.h
@@ -12,8 +12,8 @@ typedef enum {
         CAMERA_BACKWARD,
         CAMERA_LEFT,
         CAMERA_RIGHT,
-	CAMERA_UP,
-	CAMERA_DOWN
+        CAMERA_UP,
+        CAMERA_DOWN
 } CAMERA_DIRECTION;
 
 /**
@@ -51,7 +51,8 @@ typedef struct {
  * @param config Settings to be applied to the camera
  * @param camera Camera struct to be initalized.
  * @param position Initial position of the camera in 3D space. */
-void camera_init(const game_config_t* config, camera_t* camera, vec3 position);
+void camera_init(const game_config_t* config, camera_t* camera,
+                 vec3 position);
 
 /**
  * @brief Updates the right, front and up vectors of the camera. Has to be
@@ -89,7 +90,8 @@ void camera_rotate(camera_t* camera, float x_pos, float y_pos,
                    GLboolean constrain_pitch);
 
 /**
- * @brief Used to tell the camera that the mouse went out of the window so that
- * it can prevent jumping whenever the mouse comes back on the window. */
+ * @brief Used to tell the camera that the mouse went out of the window so
+ * that it can prevent jumping whenever the mouse comes back on the window.
+ */
 void camera_reset_mouse(void);
 #endif

--- a/include/camera.h
+++ b/include/camera.h
@@ -48,8 +48,10 @@ typedef struct {
 /**
  * @brief Initializes the camera vectors and puts it at the
  * orgin of the world.
- * @param camera Camera struct to be initalized. */
-void camera_init(game_config_t* config, camera_t* camera, vec3 position);
+ * @param config Settings to be applied to the camera
+ * @param camera Camera struct to be initalized.
+ * @param position Initial position of the camera in 3D space. */
+void camera_init(const game_config_t* config, camera_t* camera, vec3 position);
 
 /**
  * @brief Updates the right, front and up vectors of the camera. Has to be

--- a/include/camera.h
+++ b/include/camera.h
@@ -2,6 +2,7 @@
 #define CAMERA_H
 
 #include <GLFW/glfw3.h>
+#include <game_config.h>
 #include "cglm/types.h"
 
 /**
@@ -48,7 +49,7 @@ typedef struct {
  * @brief Initializes the camera vectors and puts it at the
  * orgin of the world.
  * @param camera Camera struct to be initalized. */
-void camera_init(camera_t* camera, vec3 position);
+void camera_init(game_config_t* config, camera_t* camera, vec3 position);
 
 /**
  * @brief Updates the right, front and up vectors of the camera. Has to be

--- a/include/chunk.h
+++ b/include/chunk.h
@@ -42,6 +42,18 @@ typedef struct {
     vec3 position;
 } chunk_t;
 
+/**
+ * @brief Represents the neighbouring chunks of a chunk. This is used
+ * to not render the face of blocks that face each other while being
+ * on different chunks.
+ */
+typedef struct {
+    const chunk_t* west;   // x-1
+    const chunk_t* east;   // x+1
+    const chunk_t* south;  // z-1
+    const chunk_t* north;  // z+1
+} chunk_neighbours_t;
+
 /** 
  * @brief Initializes a chunk to be full of air.
  * @param chunk Pointer to the chunk that will be initalized.
@@ -73,7 +85,7 @@ void chunk_mesh_push_face(chunk_mesh_t* mesh, float x, float y, float z,
  * @param chunk Data of all the blocks in the chunk that will be analyzed.
  * @param mesh Pointer to the mesh struct that will be filled with all
  * necesarry faces and sent to the GPU. */
-void chunk_build_mesh(const chunk_t* chunk, chunk_mesh_t* mesh);
+void chunk_build_mesh(const chunk_t* chunk, chunk_mesh_t* mesh, chunk_neighbours_t neighbors);
 
 /**
  * @brief Uploads a mesh to the GPU. Is meant to be used inside

--- a/include/chunk.h
+++ b/include/chunk.h
@@ -8,17 +8,16 @@
 #include <material.h>
 
 #define CHUNK_SIZE_XZ 16
-#define CHUNK_SIZE_Y 32
+#define CHUNK_SIZE_Y 512
 
 static const size_t STARTING_CHUNK_CAPACITY = 1024;
 
 /**
  * @brief Each chunk will be made of a certain amount of vertices. The
- * total amount depends on the number of blocks in the chunk. */
-typedef struct {
-    float x, y, z;
-    float u, v;
-} chunk_vertex_t;
+ * total amount depends on the number of blocks in the chunk. The values are packed into a
+ * signle uint32_t and are then unpacked in the vertex shader to lighten the
+ * rendering process by lightening the buffer data sent to the GPU. */
+typedef uint32_t chunk_vertex_t;
 
 /**
  * @brief Represents the mesh of a chunk. This is then rendered by OpenGL
@@ -75,7 +74,7 @@ void chunk_mesh_init(chunk_mesh_t* mesh);
  * @param face_vertices 4 corners of the face
  * @param uv_offset_x, uv_offset_y Texture atlas offset
  * @param uv_size Size of one tile in the atlas.*/
-void chunk_mesh_push_face(chunk_mesh_t* mesh, float x, float y, float z,
+void chunk_mesh_push_face(chunk_mesh_t* mesh, uint8_t x, uint16_t y, uint8_t z,
                           float face_vertices[4][3], float uv_offset_x,
                           float uv_offset_y, float uv_size);
 /**
@@ -111,6 +110,18 @@ void chunk_draw(chunk_t* chunk, shader_t* shader, material_t* atlas);
  * @brief Destroys the allocated memory used for a chunk mesh.
  * @param mesh Pointer to the chunk mesh struct to be freed. */
 void chunk_mesh_destroy(chunk_mesh_t* mesh);
+
+/**
+ * Packs the 5 values (that in total make 20 bytes of data) we need for each vertex into
+ * a uint32_t to lighten the buffer data.
+ * @param x X coordinate of the vertex in 3D space. (5 bits [0-16])
+ * @param y Y coordinate of the vertex in 3D space. (5 bits [0-16])
+ * @param z Z coordinate of the vertex in 3D space. (10 bits [0-512])
+ * @param u Texture coordinate U. (3 bits (0, 1, 2, or 3 divided by 4.))
+ * @param v Texture coordinate V. (3 bits (0, 1, 2, or 3 divided by 4.))
+ * @return Packed vertex data for efficient storage and transmission.
+ */
+uint32_t chunk_vertex_pack(uint8_t x, uint16_t y, uint8_t z, float u, float v);
 
 /**
  * @brief Destroys the chunk struct storing the cubes infos.

--- a/include/chunk.h
+++ b/include/chunk.h
@@ -75,7 +75,7 @@ void chunk_mesh_init(chunk_mesh_t* mesh);
  * @param uv_offset_x, uv_offset_y Texture atlas offset
  * @param uv_size Size of one tile in the atlas.*/
 void chunk_mesh_push_face(chunk_mesh_t* mesh, uint8_t x, uint16_t y, uint8_t z,
-                          float face_vertices[4][3], float uv_offset_x,
+                          bool face_vertices[4][3], float uv_offset_x,
                           float uv_offset_y, float uv_size);
 /**
  * @brief Builds a mesh and pushes it to the GPU based on the block array
@@ -83,7 +83,11 @@ void chunk_mesh_push_face(chunk_mesh_t* mesh, uint8_t x, uint16_t y, uint8_t z,
  * object.
  * @param chunk Data of all the blocks in the chunk that will be analyzed.
  * @param mesh Pointer to the mesh struct that will be filled with all
- * necesarry faces and sent to the GPU. */
+ * necesarry faces and sent to the GPU.
+ * @param neighbors Struct containing 4 pointers to the neighbours of the chunk. The neighbours are checked when
+ * the blocks of the current chunk are on the edge, so the chunk does not render a face that is facing a face from
+ * a neighbouring chunk.
+ */
 void chunk_build_mesh(const chunk_t* chunk, chunk_mesh_t* mesh, chunk_neighbours_t neighbors);
 
 /**

--- a/include/game_config.h
+++ b/include/game_config.h
@@ -1,0 +1,35 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include <stdint.h>
+
+/**
+ * @brief Configuration constants and runtime settings for the application.
+ */
+typedef struct {
+    /* Window settings */
+    uint16_t width, height;
+    const char *title;
+
+    /* Filepath for assets */
+    const char* vertex_shader_path;
+    const char* fragment_shader_path;
+    const char* texture_atlas_path;
+
+    /* Camera settings */
+    float sensitivity;
+    float speed;
+    float fov;
+
+    /* World settings */
+    float max_reach;
+    float sky_color[4];
+} game_config_t;
+
+/**
+ * @brief Returns the default configuration settings for the game.
+ * @return Config - Default configuration settings
+ */
+game_config_t game_config_default(void);
+
+#endif //CONFIG_H

--- a/include/pointer.h
+++ b/include/pointer.h
@@ -31,8 +31,10 @@ block_type_t get_pointed_block(world_t* world, camera_t* camera,
  * at.
  * @param last Last axis hit by the ray-cast. Allows us to know which face
  * of the block is being pointed at.
+ * @param pointed_block The pointer to the vector that will be filled with the coordinates
+ * of the currently targeted block.
  * @param neighbour_block The pointer to the vector that will be filled
- * with information about the neighbouring block once found.
+ * with the coordinates of the neighbouring block once found.
  * @param step_x, step_y, step_z Distances to travel to get to the
  * neighbour block.*/
 void process_block(vec3 block_position, axis_t last, vec3* pointed_block,

--- a/include/shader.h
+++ b/include/shader.h
@@ -22,39 +22,39 @@ void shader_init(shader_t* s, const char* vertex_filepath,
 /**
  * @brief Makes this shader in use by the program.
  * @param s Shader to make the program use. */
-void shader_use(shader_t* s);
+void shader_use(const shader_t* s);
 
 /**
  * @brief Frees the shader program at s from memory.
  * @param s Shader to destroy. */
-void shader_destroy(shader_t* s);
+void shader_destroy(const shader_t* s);
 
 /**
  * @brief Sets a new boolean uniform variable.
  * @param s Shader to modify.
  * @param name Name of uniform variable to set.
  * @param value Value to set the uniform variable to. */
-void shader_set_bool(shader_t* s, const char* name, bool value);
+void shader_set_bool(const shader_t* s, const char* name, bool value);
 
 /**
  * @brief Sets a new integer uniform variable.
  * @param s Shader to modify.
  * @param name Name of uniform variable to set.
  * @param value Value to set the uniform variable to. */
-void shader_set_int(shader_t* s, const char* name, int value);
+void shader_set_int(const shader_t* s, const char* name, int value);
 
 /**
  * @brief Sets a new floating point uniform variable.
  * @param s Shader to modify.
  * @param name Name of uniform variable to set.
  * @param value Value to set the uniform variable to. */
-void shader_set_float(shader_t* s, const char* name, float value);
+void shader_set_float(const shader_t* s, const char* name, float value);
 
 /**
  * @brief Sets a new 4x4 matrix uniform variable.
  * @param s Shader to modify.
  * @param name Name of uniform variable to set.
  * @param value Value to set the uniform variable to. */
-void shader_set_mat4(shader_t* s, const char* name, mat4 value);
+void shader_set_mat4(const shader_t* s, const char* name, mat4 value);
 
 #endif // SHADER_H

--- a/include/world.h
+++ b/include/world.h
@@ -57,7 +57,6 @@ void world_draw(world_t* world, shader_t* shader, material_t* atlas);
 void world_destroy(world_t* world);
 
 /** @brief Checks if that position exists in the world
- * @param world Pointer to the world to be checked.
  * @param position Vec3 containing the position to check.
  */
 bool world_valid_position(const vec3 position);

--- a/include/world.h
+++ b/include/world.h
@@ -25,6 +25,22 @@ void world_init(world_t* world);
  */
 void world_build(world_t* world);
 
+/** @brief Rebuilds a sigle chunk of the world. */
+static void world_build_chunk(world_t* world, int cx, int cz);
+
+/**
+ * Rebuilds the mesh of a chunk and any neighbors whose visible geometry
+ * changed because a border block was modified.
+ * @param world Pointer to the world that will be modified
+ * @param chunk_x Chunk grid X of the modified chunk.
+ * @param chunk_z Chunk grid Z of the modified chunk.
+ * @param local_x Block's local X within the chunk.
+ * @param local_z Block's local Z within the chunk.
+ */
+void world_rebuild_after_change(world_t* world,
+                                      int chunk_x, int chunk_z,
+                                      int local_x, int local_z);
+
 /**
  * Uses a world, a shader and a texture atlas to draw all the chunks
  * on screen.

--- a/include/world.h
+++ b/include/world.h
@@ -26,7 +26,7 @@ void world_init(world_t* world);
 void world_build(world_t* world);
 
 /** @brief Rebuilds a sigle chunk of the world. */
-static void world_build_chunk(world_t* world, int cx, int cz);
+void world_build_chunk(world_t* world, int cx, int cz);
 
 /**
  * Rebuilds the mesh of a chunk and any neighbors whose visible geometry

--- a/src/camera.c
+++ b/src/camera.c
@@ -7,15 +7,13 @@
 
 static const float CAMERA_YAW = -90.0f;
 static const float CAMERA_PITCH = 0.0f;
-static const float CAMERA_SPEED = 5.0f;
-static const float CAMERA_SENSITIVIY = 0.05f;
 static const float CAMERA_ZOOM = 45.0f;
 
 static float last_mouse_x = 0;
 static float last_mouse_y = 0;
 static bool first_mouse = true;
 
-void camera_init(game_config_t* cfg, camera_t* camera, vec3 position) {
+void camera_init(const game_config_t* config, camera_t* camera, vec3 position) {
         /* Setting up the camera's intial position.*/
         glm_vec3_copy(position, camera->position);
 
@@ -25,8 +23,8 @@ void camera_init(game_config_t* cfg, camera_t* camera, vec3 position) {
         /* Setting the default parameter of the camera */
         camera->yaw = CAMERA_YAW;
         camera->pitch = CAMERA_PITCH;
-        camera->movement_speed = CAMERA_SPEED;
-        camera->mouse_sensitivity = CAMERA_SENSITIVIY;
+        camera->movement_speed = config->speed;
+        camera->mouse_sensitivity = config->sensitivity;
         camera->zoom = CAMERA_ZOOM;
 
         glm_vec3_copy((vec3) {0.0f, 1.0f, 0.0f}, camera->world_up);

--- a/src/camera.c
+++ b/src/camera.c
@@ -15,7 +15,7 @@ static float last_mouse_x = 0;
 static float last_mouse_y = 0;
 static bool first_mouse = true;
 
-void camera_init(camera_t* camera, vec3 position) {
+void camera_init(game_config_t* cfg, camera_t* camera, vec3 position) {
         /* Setting up the camera's intial position.*/
         glm_vec3_copy(position, camera->position);
 

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -196,25 +196,28 @@ void chunk_mesh_upload(const chunk_mesh_t* mesh) {
         glBindVertexArray(mesh->vao);
 
         glBindBuffer(GL_ARRAY_BUFFER, mesh->vbo);
-        glBufferData(GL_ARRAY_BUFFER,
-                     (GLsizeiptr)(mesh->vertex_count * sizeof(chunk_vertex_t)),
-                     mesh->vertices, GL_DYNAMIC_DRAW);
+        glBufferData(
+            GL_ARRAY_BUFFER,
+            (GLsizeiptr)(mesh->vertex_count * sizeof(chunk_vertex_t)),
+            mesh->vertices, GL_DYNAMIC_DRAW);
 
-        /** Since all of our data is packed into an uint32_t, no need to to pass
-         * multiple attributes. The unpacking will be done in the vertex shader. */
+        /** Since all of our data is packed into an uint32_t, no need to to
+         * pass multiple attributes. The unpacking will be done in the
+         * vertex shader. */
         glVertexAttribIPointer(0, 1, GL_UNSIGNED_INT, sizeof(uint32_t), 0);
         glEnableVertexAttribArray(0);
 
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh->eao);
-        glBufferData(GL_ELEMENT_ARRAY_BUFFER,
-                     (GLsizeiptr)(mesh->index_count * sizeof(unsigned int)),
-                     mesh->indices, GL_DYNAMIC_DRAW);
+        glBufferData(
+            GL_ELEMENT_ARRAY_BUFFER,
+            (GLsizeiptr)(mesh->index_count * sizeof(unsigned int)),
+            mesh->indices, GL_DYNAMIC_DRAW);
 }
 
 void chunk_mesh_draw(const chunk_mesh_t* mesh) {
         glBindVertexArray(mesh->vao);
-        glDrawElements(GL_TRIANGLES, (int)mesh->index_count, GL_UNSIGNED_INT,
-                       0);
+        glDrawElements(GL_TRIANGLES, (int)mesh->index_count,
+                       GL_UNSIGNED_INT, 0);
         glBindVertexArray(0);
 }
 

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -116,7 +116,8 @@ void chunk_mesh_push_face(chunk_mesh_t* mesh, const float x, const float y, cons
         mesh->indices[mesh->index_count++] = base + 0;
 }
 
-void chunk_build_mesh(const chunk_t* chunk, chunk_mesh_t* mesh) {
+void chunk_build_mesh(const chunk_t* chunk,
+    chunk_mesh_t* mesh, chunk_neighbours_t neighbors) {
     // clang-format off
     mesh->vertex_count = 0;
     mesh->index_count = 0;
@@ -130,31 +131,48 @@ void chunk_build_mesh(const chunk_t* chunk, chunk_mesh_t* mesh) {
 
                 const block_uv_t uv = BLOCK_UVS[block];
 
-                /* Checking the X,Y,Z coordinates of each block, in front
-                 * and behind.*/
-                if (z == CHUNK_SIZE_XZ - 1 ||
-                    chunk->blocks[x][y][z + 1] == BLOCK_AIR)
-                    chunk_mesh_push_face(mesh, x, y, z, FACE_FRONT,
-				    uv.front.u, uv.front.v, TILE_OFFSET);
-                if (z == 0 || chunk->blocks[x][y][z - 1] == BLOCK_AIR)
-                    chunk_mesh_push_face(mesh, x, y, z, FACE_BACK, 
-				    uv.back.u, uv.back.v, TILE_OFFSET);
+                /* To determine if the face of a block in a chunk will be rendered, we check
+                 * the 4 potentials neighbors (front, back, left and right). The top and
+                 * bottom chunks do not exist. If a block is found in the neighbouring
+                 * chunk, then the face is not rendered. If the chunk is at the edge
+                 * of the world, then the face is rendered. */
+                if (z == CHUNK_SIZE_XZ - 1) {
+                    // Front-checking
+                    if (!neighbors.north || neighbors.north->blocks[x][y][0] == BLOCK_AIR)
+                        chunk_mesh_push_face(mesh, x, y, z, FACE_FRONT, uv.front.u, uv.front.v, TILE_OFFSET);
+                } else if (chunk->blocks[x][y][z + 1] == BLOCK_AIR) {
+                    chunk_mesh_push_face(mesh, x, y, z, FACE_FRONT, uv.front.u, uv.front.v, TILE_OFFSET);
+                }
 
-                if (y == CHUNK_SIZE_XZ - 1 ||
-                    chunk->blocks[x][y + 1][z] == BLOCK_AIR)
-                    chunk_mesh_push_face(mesh, x, y, z, FACE_TOP,
-				    uv.top.u, uv.top.v, TILE_OFFSET);
+                if (z == 0) {
+                    // Back-checking
+                    if (!neighbors.south || neighbors.south->blocks[x][y][CHUNK_SIZE_XZ - 1] == BLOCK_AIR)
+                        chunk_mesh_push_face(mesh, x, y, z, FACE_BACK, uv.back.u, uv.back.v, TILE_OFFSET);
+                } else if (chunk->blocks[x][y][z - 1] == BLOCK_AIR) {
+                    chunk_mesh_push_face(mesh, x, y, z, FACE_BACK, uv.back.u, uv.back.v, TILE_OFFSET);
+                }
+
+                if (y == CHUNK_SIZE_Y - 1 || chunk->blocks[x][y + 1][z] == BLOCK_AIR)
+                    chunk_mesh_push_face(mesh, x, y, z, FACE_TOP, uv.top.u, uv.top.v, TILE_OFFSET);
+
                 if (y == 0 || chunk->blocks[x][y - 1][z] == BLOCK_AIR)
-                    chunk_mesh_push_face(mesh, x, y, z, FACE_BOTTOM, 
-				    uv.bottom.u, uv.bottom.v, TILE_OFFSET);
+                    chunk_mesh_push_face(mesh, x, y, z, FACE_BOTTOM, uv.bottom.u, uv.bottom.v, TILE_OFFSET);
 
-                if (x == CHUNK_SIZE_XZ - 1 ||
-                    chunk->blocks[x + 1][y][z] == BLOCK_AIR)
-                    chunk_mesh_push_face(mesh, x, y, z, FACE_RIGHT,
-				    uv.right.u, uv.right.v, TILE_OFFSET);
-                if (x == 0 || chunk->blocks[x - 1][y][z] == BLOCK_AIR)
-                    chunk_mesh_push_face(mesh, x, y, z, FACE_LEFT,
-				    uv.left.u, uv.left.v, TILE_OFFSET);
+                if (x == CHUNK_SIZE_XZ - 1) {
+                    // Right-checking
+                    if (!neighbors.east || neighbors.east->blocks[0][y][z] == BLOCK_AIR)
+                        chunk_mesh_push_face(mesh, x, y, z, FACE_RIGHT, uv.right.u, uv.right.v, TILE_OFFSET);
+                } else if (chunk->blocks[x + 1][y][z] == BLOCK_AIR) {
+                    chunk_mesh_push_face(mesh, x, y, z, FACE_RIGHT, uv.right.u, uv.right.v, TILE_OFFSET);
+                }
+
+                if (x == 0) {
+                    // Left-checking
+                    if (!neighbors.west || neighbors.west->blocks[CHUNK_SIZE_XZ - 1][y][z] == BLOCK_AIR)
+                        chunk_mesh_push_face(mesh, x, y, z, FACE_LEFT, uv.left.u, uv.left.v, TILE_OFFSET);
+                } else if (chunk->blocks[x - 1][y][z] == BLOCK_AIR) {
+                    chunk_mesh_push_face(mesh, x, y, z, FACE_LEFT, uv.left.u, uv.left.v, TILE_OFFSET);
+                }
             }
         }
     }

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -13,22 +13,22 @@
 
 // clang-format off
 /* These are all the different vertices for a face that are needed. */
-static float FACE_FRONT[4][3] = {
+static bool FACE_FRONT[4][3] = {
 	{0, 0, 1}, {1, 0, 1}, {1, 1, 1}, {0, 1, 1}};
 
-static float FACE_BACK[4][3] = {
+static bool FACE_BACK[4][3] = {
 	{1, 0, 0}, {0, 0, 0}, {0, 1, 0}, {1, 1, 0}};
 
-static float FACE_LEFT[4][3] = {
+static bool FACE_LEFT[4][3] = {
 	{0, 0, 0}, {0, 0, 1}, {0, 1, 1}, {0, 1, 0}};
 
-static float FACE_RIGHT[4][3] = {
+static bool FACE_RIGHT[4][3] = {
 	{1, 0, 1}, {1, 0, 0}, {1, 1, 0}, {1, 1, 1}};
 
-static float FACE_TOP[4][3] = {
+static bool FACE_TOP[4][3] = {
 	{0, 1, 1}, {1, 1, 1}, {1, 1, 0}, {0, 1, 0}};
 
-static float FACE_BOTTOM[4][3] = {
+static bool FACE_BOTTOM[4][3] = {
 	{0, 0, 0}, {1, 0, 0}, {1, 0, 1}, {0, 0, 1}};
 //clang-format on
 
@@ -53,7 +53,7 @@ void chunk_mesh_init(chunk_mesh_t* mesh) {
 }
 
 void chunk_mesh_push_face(chunk_mesh_t* mesh, const uint8_t x, const uint16_t y, const uint8_t z,
-                          float face_vertices[4][3], const float uv_offset_x,
+                          bool face_vertices[4][3], const float uv_offset_x,
                           const float uv_offset_y, const float uv_size) {
         /* Checking if vertices and indices array need to be reallocated.
          * To add a face, we need 4 new vertices. And for each face added,
@@ -117,7 +117,7 @@ void chunk_mesh_push_face(chunk_mesh_t* mesh, const uint8_t x, const uint16_t y,
 }
 
 void chunk_build_mesh(const chunk_t* chunk,
-    chunk_mesh_t* mesh, chunk_neighbours_t neighbors) {
+    chunk_mesh_t* mesh, const chunk_neighbours_t neighbors) {
     // clang-format off
     mesh->vertex_count = 0;
     mesh->index_count = 0;
@@ -197,7 +197,7 @@ void chunk_mesh_upload(const chunk_mesh_t* mesh) {
 
         glBindBuffer(GL_ARRAY_BUFFER, mesh->vbo);
         glBufferData(GL_ARRAY_BUFFER,
-                     mesh->vertex_count * sizeof(chunk_vertex_t),
+                     (GLsizeiptr)(mesh->vertex_count * sizeof(chunk_vertex_t)),
                      mesh->vertices, GL_DYNAMIC_DRAW);
 
         /** Since all of our data is packed into an uint32_t, no need to to pass
@@ -207,13 +207,13 @@ void chunk_mesh_upload(const chunk_mesh_t* mesh) {
 
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh->eao);
         glBufferData(GL_ELEMENT_ARRAY_BUFFER,
-                     mesh->index_count * sizeof(unsigned int),
+                     (GLsizeiptr)(mesh->index_count * sizeof(unsigned int)),
                      mesh->indices, GL_DYNAMIC_DRAW);
 }
 
 void chunk_mesh_draw(const chunk_mesh_t* mesh) {
         glBindVertexArray(mesh->vao);
-        glDrawElements(GL_TRIANGLES, mesh->index_count, GL_UNSIGNED_INT,
+        glDrawElements(GL_TRIANGLES, (int)mesh->index_count, GL_UNSIGNED_INT,
                        0);
         glBindVertexArray(0);
 }

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -52,7 +52,7 @@ void chunk_mesh_init(chunk_mesh_t* mesh) {
         glGenBuffers(1, &mesh->eao);
 }
 
-void chunk_mesh_push_face(chunk_mesh_t* mesh, const float x, const float y, const float z,
+void chunk_mesh_push_face(chunk_mesh_t* mesh, const uint8_t x, const uint16_t y, const uint8_t z,
                           float face_vertices[4][3], const float uv_offset_x,
                           const float uv_offset_y, const float uv_size) {
         /* Checking if vertices and indices array need to be reallocated.
@@ -97,13 +97,13 @@ void chunk_mesh_push_face(chunk_mesh_t* mesh, const float x, const float y, cons
          * allowing a quick access to the necessary offset for each
          * vertex.*/
         for (uint8_t i = 0; i < 4; ++i) {
-                mesh->vertices[mesh->vertex_count++] = (chunk_vertex_t) {
-                    .x = x + face_vertices[i][0],
-                    .y = y + face_vertices[i][1],
-                    .z = z + face_vertices[i][2],
-                    .u = uvs[i][0],
-                    .v = uvs[i][1],
-                };
+                mesh->vertices[mesh->vertex_count++] = chunk_vertex_pack(
+                        x + face_vertices[i][0],
+                        y + face_vertices[i][1],
+                        z + face_vertices[i][2],
+                        uvs[i][0],
+                        uvs[i][1]
+                );
         }
 
         /* Here we push 6 indices, which will draw two triangles, which in
@@ -124,7 +124,7 @@ void chunk_build_mesh(const chunk_t* chunk,
     /* Big ass check on ALL cubes and sending each facing that face
      * BLOCK_AIR to the chunk mesh to be built. */
     for (uint8_t x = 0; x < CHUNK_SIZE_XZ; ++x) {
-        for (uint8_t y = 0; y < CHUNK_SIZE_Y; ++y) {
+        for (uint16_t y = 0; y < CHUNK_SIZE_Y; ++y) {
             for (uint8_t z = 0; z < CHUNK_SIZE_XZ; ++z) {
                 const uint8_t block = chunk->blocks[x][y][z];
                 if (block == BLOCK_AIR) continue;
@@ -179,6 +179,17 @@ void chunk_build_mesh(const chunk_t* chunk,
     chunk_mesh_upload(mesh);
 }
 
+uint32_t chunk_vertex_pack(const uint8_t x, const uint16_t y,
+    const uint8_t z, const float u, const float v) {
+    const uint32_t u_idx = (uint32_t)roundf(u / TILE_OFFSET);
+    const uint32_t v_idx = (uint32_t)roundf(v / TILE_OFFSET);
+    return  (x & 0x1Fu)
+          | ((z & 0x1Fu) << 5u)
+          | ((y & 0x3FFu) << 10u)
+          | (u_idx << 20u)
+          | (v_idx << 23u);
+}
+
 // clang-format on
 
 void chunk_mesh_upload(const chunk_mesh_t* mesh) {
@@ -189,19 +200,10 @@ void chunk_mesh_upload(const chunk_mesh_t* mesh) {
                      mesh->vertex_count * sizeof(chunk_vertex_t),
                      mesh->vertices, GL_DYNAMIC_DRAW);
 
-        /* offsetof is a function giving the byte offset of a member in a
-         * struct. Very useful in our case here. x is the start of the
-         * first attribute and is 3 floats (x, y and z.). Then we tell
-         * OpenGL that our second attribute starts at the u and will be u
-         * and v (the texture coordinates on the atlas.) */
-        glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE,
-                              sizeof(chunk_vertex_t),
-                              (void*)offsetof(chunk_vertex_t, x));
+        /** Since all of our data is packed into an uint32_t, no need to to pass
+         * multiple attributes. The unpacking will be done in the vertex shader. */
+        glVertexAttribIPointer(0, 1, GL_UNSIGNED_INT, sizeof(uint32_t), 0);
         glEnableVertexAttribArray(0);
-        glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE,
-                              sizeof(chunk_vertex_t),
-                              (void*)offsetof(chunk_vertex_t, u));
-        glEnableVertexAttribArray(1);
 
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh->eao);
         glBufferData(GL_ELEMENT_ARRAY_BUFFER,

--- a/src/game_config.c
+++ b/src/game_config.c
@@ -1,0 +1,16 @@
+#include <game_config.h>
+game_config_t game_config_default(void) {
+    return (game_config_t){
+        .width                = 800,
+        .height               = 600,
+        .title                = "da-cubec",
+        .vertex_shader_path   = "src/shaders/basic.vert.glsl",
+        .fragment_shader_path = "src/shaders/basic.frag.glsl",
+        .texture_atlas_path   = "img/atlas.png",
+        .sensitivity          = 0.05f,
+        .speed                = 5.0f,
+        .fov                  = 70.0f,
+        .max_reach            = 6.0f,
+        .sky_color            = {0.85f, 0.85f, 1.0f, 1.0f},
+    };
+}

--- a/src/main.c
+++ b/src/main.c
@@ -80,7 +80,7 @@ int main(void) {
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
         glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
-        game_config_t config = game_config_default();
+        const game_config_t config = game_config_default();
 
         /* Creating window */
         GLFWwindow* window =

--- a/src/main.c
+++ b/src/main.c
@@ -128,9 +128,9 @@ int main(void) {
                     config.fragment_shader_path);
 
         camera_init(&config, &main_camera, (vec3) {
-                (float)WORLD_SIZE_X * CHUNK_SIZE_XZ / 2,
-                (float)CHUNK_SIZE_Y / 2,
-                (float)WORLD_SIZE_X * CHUNK_SIZE_XZ / 2
+                (float)WORLD_SIZE_X * CHUNK_SIZE_XZ / 2.0f,
+                20.f,
+                (float)WORLD_SIZE_X * CHUNK_SIZE_XZ / 2.0f
         });
 
         world_init(&world);
@@ -313,6 +313,7 @@ void process_block_inputs(GLFWwindow* window) {
                 const int lz = (int)neighbour[2] % CHUNK_SIZE_XZ;
                 const int cx = (int)neighbour[0] / CHUNK_SIZE_XZ;
                 const int cz = (int)neighbour[2] / CHUNK_SIZE_XZ;
+                if (target_chunk->blocks[lx][ly][lz] != BLOCK_AIR) return;
                 target_chunk->blocks[lx][ly][lz] = BLOCK_COBBLESTONE;
                 world_rebuild_after_change(&world, cx, cz, lx, lz);
         }

--- a/src/main.c
+++ b/src/main.c
@@ -14,6 +14,7 @@
 #include <blocks.h>
 #include <chunk.h>
 #include <pointer.h>
+#include <game_config.h>
 
 const uint16_t WIDTH = 800, HEIGHT = 600;
 const char* const WINDOW_TITLE = "da-cubec";
@@ -48,7 +49,6 @@ static bool focused = false;
  * @brief Called every time a key is pressed. */
 void key_callback(GLFWwindow* window, int key, int scancode, int action,
                   int mode);
-
 /**
  * @brief Rotates camera if mouse is locked in the window. */
 void mouse_callback(GLFWwindow* window, double x_pos, double y_pos);
@@ -80,9 +80,11 @@ int main(void) {
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
         glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
+        game_config_t config = game_config_default();
+
         /* Creating window */
         GLFWwindow* window =
-            glfwCreateWindow(WIDTH, HEIGHT, WINDOW_TITLE, NULL, NULL);
+            glfwCreateWindow(config.width, config.height, config.title, NULL, NULL);
         if (window == NULL) {
                 fprintf(stderr, "%s\n", "Failed to create GLFW window.");
                 glfwTerminate();
@@ -118,14 +120,14 @@ int main(void) {
 
         /* Creating our texture atlas */
         material_t atlas;
-        material_create(&atlas, TEXTURE_ATLAS_PATH);
+        material_create(&atlas, config.texture_atlas_path);
 
         /* Initalizing our shader */
         shader_t basic_shader;
-        shader_init(&basic_shader, VERTEX_SHADER_PATH,
-                    FRAGMENT_SHADER_PATH);
+        shader_init(&basic_shader, config.vertex_shader_path,
+                    config.fragment_shader_path);
 
-        camera_init(&main_camera, (vec3) {
+        camera_init(&config, &main_camera, (vec3) {
                 (float)WORLD_SIZE_X * CHUNK_SIZE_XZ / 2,
                 (float)CHUNK_SIZE_Y / 2,
                 (float)WORLD_SIZE_X * CHUNK_SIZE_XZ / 2
@@ -141,6 +143,7 @@ int main(void) {
         /* Enabling depth-testing so that OpenGL uses its Z-buffer to
         prioritze drawings vertices that are closer to the camera. */
         glEnable(GL_DEPTH_TEST);
+        glEnable(GL_CULL_FACE);
 
         /* We need a view matrix. To move around the world,
          * moving the camera is the same as moving the entire
@@ -291,22 +294,27 @@ void process_block_inputs(GLFWwindow* window) {
 
         /* Left-click -> The block gets destroyed (replaced with air) */
         if (lc_state == GLFW_PRESS && last_lc_state == GLFW_RELEASE) {
-                const int cx = (int)target_block[0] % CHUNK_SIZE_XZ;
-                const int cy = (int)target_block[1];
-                const int cz = (int)target_block[2] % CHUNK_SIZE_XZ;
+                const int lx = (int)target_block[0] % CHUNK_SIZE_XZ;
+                const int ly = (int)target_block[1];
+                const int lz = (int)target_block[2] % CHUNK_SIZE_XZ;
+                const int cx = (int)target_block[0] / CHUNK_SIZE_XZ;
+                const int cz = (int)target_block[2] / CHUNK_SIZE_XZ;
+
                 /** Destroying the block that is being looked at **/
-                target_chunk->blocks[cx][cy][cz] = BLOCK_AIR;
-                chunk_build_mesh(target_chunk, &target_chunk->mesh);
+                target_chunk->blocks[lx][ly][lz] = BLOCK_AIR;
+                world_rebuild_after_change(&world, cx, cz, lx, lz);
         }
 
         /* Right-click -> A block is placed at the neighbour coordinates. */
         if (rc_state == GLFW_PRESS && last_rc_state == GLFW_RELEASE) {
                 if (!world_valid_position(neighbour)) return;
-                const int nx = (int)neighbour[0] % CHUNK_SIZE_XZ;
-                const int ny = (int)neighbour[1];
-                const int nz = (int)neighbour[2] % CHUNK_SIZE_XZ;
-                target_chunk->blocks[nx][ny][nz] = BLOCK_COBBLESTONE;
-                chunk_build_mesh(target_chunk, &target_chunk->mesh);
+                const int lx = (int)neighbour[0] % CHUNK_SIZE_XZ;
+                const int ly = (int)neighbour[1];
+                const int lz = (int)neighbour[2] % CHUNK_SIZE_XZ;
+                const int cx = (int)neighbour[0] / CHUNK_SIZE_XZ;
+                const int cz = (int)neighbour[2] / CHUNK_SIZE_XZ;
+                target_chunk->blocks[lx][ly][lz] = BLOCK_COBBLESTONE;
+                world_rebuild_after_change(&world, cx, cz, lx, lz);
         }
 
 	last_lc_state = lc_state;

--- a/src/material.c
+++ b/src/material.c
@@ -32,9 +32,9 @@ void material_create(material_t *material, const char *filename) {
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
                         GL_NEAREST_MIPMAP_NEAREST);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	/* Generating mipmap levels for LOD. No need for now. */
-	// glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
-	// glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 4);
+		/* Generating mipmap levels for LOD. No need for now. */
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 4);
 }
 
 void material_use(material_t *material, int unit) {

--- a/src/shader.c
+++ b/src/shader.c
@@ -9,27 +9,27 @@ void shader_init(shader_t* s, const char* vertex_filepath,
         s->id = make_shader(vertex_filepath, fragment_filepath);
 }
 
-void shader_use(shader_t* s) {
+void shader_use(const shader_t* s) {
         glUseProgram(s->id);
 }
 
-void shader_destroy(shader_t* s) {
+void shader_destroy(const shader_t* s) {
         glDeleteProgram(s->id);
 }
 
-void shader_set_bool(shader_t* s, const char* name, bool value) {
+void shader_set_bool(const shader_t* s, const char* name, const bool value) {
         glUniform1i(glGetUniformLocation(s->id, name), (int)value);
 }
 
-void shader_set_int(shader_t* s, const char* name, int value) {
+void shader_set_int(const shader_t* s, const char* name, const int value) {
         glUniform1i(glGetUniformLocation(s->id, name), value);
 }
 
-void shader_set_float(shader_t* s, const char* name, float value) {
+void shader_set_float(const shader_t* s, const char* name, const float value) {
         glUniform1f(glGetUniformLocation(s->id, name), value);
 }
 
-void shader_set_mat4(shader_t* s, const char* name, mat4 value) {
+void shader_set_mat4(const shader_t* s, const char* name, mat4 value) {
         glUniformMatrix4fv(glGetUniformLocation(s->id, name), 1, GL_FALSE,
                            (float*)value);
 }

--- a/src/shaders/basic.vert.glsl
+++ b/src/shaders/basic.vert.glsl
@@ -1,7 +1,6 @@
 #version 330 core
 
-layout (location = 0) in vec3 aPos;
-layout (location = 1) in vec2 aTexCoord;
+layout (location = 0) in uint packed_data;
 
 out vec2 texture_coordinates;
 
@@ -10,6 +9,13 @@ uniform mat4 view;
 uniform mat4 projection;
 
 void main() {
-	gl_Position = projection * view * model * vec4(aPos.x, aPos.y, aPos.z, 1.0);
-	texture_coordinates = aTexCoord;
+	/* Unpacking the vertex data packed into a 32 bit unsigned int. */
+	float x = float(packed_data & 0x01Fu);
+	float z = float((packed_data >> 5u) & 0x01Fu);
+	float y = float((packed_data >> 10u) & 0x3FFu);
+	float u = float((packed_data >> 20u) & 0x007u) * 0.25;
+	float v = float((packed_data >> 23u) & 0x007u) * 0.25;
+
+	gl_Position = projection * view * model * vec4(x, y, z, 1.0);
+	texture_coordinates = vec2(u,v);
 }

--- a/src/utils/io_utils.c
+++ b/src/utils/io_utils.c
@@ -18,7 +18,7 @@ int read_file(const char* filepath, const char** const out) {
                 return -1;
         }
 
-        long fsize = ftell(fptr);
+        const long fsize = ftell(fptr);
         if (fsize == -1) {
                 perror("Error getting file size");
                 fclose(fptr);

--- a/src/utils/shader_utils.c
+++ b/src/utils/shader_utils.c
@@ -1,21 +1,20 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <glad/gl.h>
-#include <GLFW/glfw3.h>
 
 #include <utils/shader_utils.h>
 #include <utils/io_utils.h>
 
-unsigned int make_module(const char* filepath, unsigned int module_type) {
+unsigned int make_module(const char* filepath, const unsigned int module_type) {
         const char* source = NULL;
-        int read_status = read_file(filepath, &source);
+        const int read_status = read_file(filepath, &source);
         if (read_status == -1) {
                 fprintf(stderr, "%s\n",
                         "Shader source file could not be read.");
         }
 
         // Assigning shader and source code to module
-        unsigned int shader_module = glCreateShader(module_type);
+        const unsigned int shader_module = glCreateShader(module_type);
         glShaderSource(shader_module, 1, &source, NULL);
         glCompileShader(shader_module);
 
@@ -36,13 +35,13 @@ unsigned int make_module(const char* filepath, unsigned int module_type) {
 
 unsigned int make_shader(const char* vertex_filepath,
                          const char* fragment_filepath) {
-        unsigned int vertex_module =
+        const unsigned int vertex_module =
             make_module(vertex_filepath, GL_VERTEX_SHADER);
-        unsigned int fragment_module =
+        const unsigned int fragment_module =
             make_module(fragment_filepath, GL_FRAGMENT_SHADER);
 
         // Create the shader program with both our modules
-        unsigned int shader = glCreateProgram();
+        const unsigned int shader = glCreateProgram();
         glAttachShader(shader, vertex_module);
         glAttachShader(shader, fragment_module);
 

--- a/src/world.c
+++ b/src/world.c
@@ -18,30 +18,32 @@ void world_init(world_t* world) {
 
 void world_build(world_t* world) {
         for (int x = 0; x < WORLD_SIZE_X; x++)
-        for (int z = 0; z < WORLD_SIZE_Z; z++) {
-                world_build_chunk(world, x, z);
-        }
+                for (int z = 0; z < WORLD_SIZE_Z; z++) {
+                        world_build_chunk(world, x, z);
+                }
 }
 
 void world_build_chunk(world_t* world, const int cx, const int cz) {
         const chunk_neighbours_t neighbors = {
-                .west  = (cx > 0)                ? &world->chunks[cx - 1][cz] : NULL,
-                .east  = (cx < WORLD_SIZE_X - 1) ? &world->chunks[cx + 1][cz] : NULL,
-                .south = (cz > 0)                ? &world->chunks[cx][cz - 1] : NULL,
-                .north = (cz < WORLD_SIZE_Z - 1) ? &world->chunks[cx][cz + 1] : NULL,
-            };
+            .west = (cx > 0) ? &world->chunks[cx - 1][cz] : NULL,
+            .east = (cx < WORLD_SIZE_X - 1) ? &world->chunks[cx + 1][cz]
+                                            : NULL,
+            .south = (cz > 0) ? &world->chunks[cx][cz - 1] : NULL,
+            .north = (cz < WORLD_SIZE_Z - 1) ? &world->chunks[cx][cz + 1]
+                                             : NULL,
+        };
         chunk_t* chunk = &world->chunks[cx][cz];
         chunk_build_mesh(chunk, &chunk->mesh, neighbors);
 }
 
-void world_rebuild_after_change(world_t* world,
-        const int chunk_x, const int chunk_z,
-        const int local_x, const int local_z) {
+void world_rebuild_after_change(world_t* world, const int chunk_x,
+                                const int chunk_z, const int local_x,
+                                const int local_z) {
         /* Building the centre chunk, where the camera is */
         world_build_chunk(world, chunk_x, chunk_z);
 
-        /* Rebuilding the correct chunk depending on which edge the camera is
-         * located at (If it is at an edge) */
+        /* Rebuilding the correct chunk depending on which edge the camera
+         * is located at (If it is at an edge) */
         if (local_x == 0 && chunk_x > 0)
                 world_build_chunk(world, chunk_x - 1, chunk_z);
         if (local_x == CHUNK_SIZE_XZ - 1 && chunk_x < WORLD_SIZE_X - 1)

--- a/src/world.c
+++ b/src/world.c
@@ -18,9 +18,38 @@ void world_init(world_t* world) {
 
 void world_build(world_t* world) {
         for (int x = 0; x < WORLD_SIZE_X; x++)
-                for (int z = 0; z < WORLD_SIZE_Z; z++)
-                        chunk_build_mesh(&world->chunks[x][z],
-                                         &world->chunks[x][z].mesh);
+        for (int z = 0; z < WORLD_SIZE_Z; z++) {
+                world_build_chunk(world, x, z);
+        }
+}
+
+static void world_build_chunk(world_t* world, int cx, int cz) {
+        chunk_neighbours_t neighbors = {
+                .west  = (cx > 0)                ? &world->chunks[cx - 1][cz] : NULL,
+                .east  = (cx < WORLD_SIZE_X - 1) ? &world->chunks[cx + 1][cz] : NULL,
+                .south = (cz > 0)                ? &world->chunks[cx][cz - 1] : NULL,
+                .north = (cz < WORLD_SIZE_Z - 1) ? &world->chunks[cx][cz + 1] : NULL,
+            };
+        chunk_t* chunk = &world->chunks[cx][cz];
+        chunk_build_mesh(chunk, &chunk->mesh, neighbors);
+}
+
+void world_rebuild_after_change(world_t* world,
+        const int chunk_x, const int chunk_z,
+        const int local_x, const int local_z) {
+        /* Building the centre chunk, where the camera is */
+        world_build_chunk(world, chunk_x, chunk_z);
+
+        /* Rebuilding the correct chunk depending on which edge the camera is
+         * located at (If it is at an edge) */
+        if (local_x == 0 && chunk_x > 0)
+                world_build_chunk(world, chunk_x - 1, chunk_z);
+        if (local_x == CHUNK_SIZE_XZ - 1 && chunk_x < WORLD_SIZE_X - 1)
+                world_build_chunk(world, chunk_x + 1, chunk_z);
+        if (local_z == 0 && chunk_z > 0)
+                world_build_chunk(world, chunk_x, chunk_z - 1);
+        if (local_z == CHUNK_SIZE_XZ - 1 && chunk_z < WORLD_SIZE_Z - 1)
+                world_build_chunk(world, chunk_x, chunk_z + 1);
 }
 
 void world_draw(world_t* world, shader_t* shader, material_t* atlas) {

--- a/src/world.c
+++ b/src/world.c
@@ -23,8 +23,8 @@ void world_build(world_t* world) {
         }
 }
 
-void world_build_chunk(world_t* world, int cx, int cz) {
-        chunk_neighbours_t neighbors = {
+void world_build_chunk(world_t* world, const int cx, const int cz) {
+        const chunk_neighbours_t neighbors = {
                 .west  = (cx > 0)                ? &world->chunks[cx - 1][cz] : NULL,
                 .east  = (cx < WORLD_SIZE_X - 1) ? &world->chunks[cx + 1][cz] : NULL,
                 .south = (cz > 0)                ? &world->chunks[cx][cz - 1] : NULL,

--- a/src/world.c
+++ b/src/world.c
@@ -23,7 +23,7 @@ void world_build(world_t* world) {
         }
 }
 
-static void world_build_chunk(world_t* world, int cx, int cz) {
+void world_build_chunk(world_t* world, int cx, int cz) {
         chunk_neighbours_t neighbors = {
                 .west  = (cx > 0)                ? &world->chunks[cx - 1][cz] : NULL,
                 .east  = (cx < WORLD_SIZE_X - 1) ? &world->chunks[cx + 1][cz] : NULL,


### PR DESCRIPTION
Thanks to online tutorials, cross chunk face culling has been implemented ! 

The world and chunk source files have been modified so that their building functions now accept a new "chunk_neighbours_t" struct which has 4 pointers to the neighbouring chunks of the currently worked-on chunk. So when a chunk is being rebuilt it can check if the neighbouring chunks have block that touch blocks on this current chunk, in that case, the face is not rendered. 

Also, when a change is made on the edge of a chunk, the corresponding neighgbouring chunk needs to then also be rebuilt, which is what was made in this PR.